### PR TITLE
Introduce first mover pattern iai examples

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,4 @@
+steps:
+  - label: "Benchmarks"
+    command:
+      - "bin/snapshot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ iai = "0.1.1"
 [[bench]]
 name = "criterion_iai_benchmark"
 harness = false
+
+[[bench]]
+name = "criterion_iai_first_mover_benchmark"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ iai = "0.1.1"
 name = "criterion_iai_benchmark"
 harness = false
 
-[[bench]]
-name = "criterion_iai_first_mover_benchmark"
-harness = false
+# NOTE: the numbers these produce are presently unstable
+#[[bench]]
+#name = "criterion_iai_first_mover_benchmark"
+#harness = false

--- a/benches/criterion_iai_first_mover_benchmark.rs
+++ b/benches/criterion_iai_first_mover_benchmark.rs
@@ -1,0 +1,67 @@
+//use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use core::sync::atomic::{AtomicBool, Ordering};
+use iai::black_box;
+
+fn assign<'a, 'b>(allocator: &'b mut [u64], src: &'a [u64]) -> u64 {
+    let mut k = 0;
+    for item in src {
+        unsafe {
+            *allocator.get_unchecked_mut(k) = *item;
+            k += 1;
+        }
+    }
+    unsafe { *allocator.get_unchecked(99) }
+}
+
+fn store_load<'a, 'b>(allocator: &'b mut [u64], src: &'a [u64]) -> u64 {
+    allocator.copy_from_slice(src);
+    unsafe { *allocator.get_unchecked(99) }
+}
+
+fn get_xs() -> &'static mut [u64; 100] {
+    static TAKEN: AtomicBool = AtomicBool::new(false);
+    if TAKEN.swap(true, Ordering::AcqRel) {
+        panic!();
+    }
+    static mut XS: [u64; 100] = [0; 100];
+    unsafe { &mut XS }
+}
+
+fn get_ys() -> &'static [u64; 100] {
+    static TAKEN: AtomicBool = AtomicBool::new(false);
+    if TAKEN.swap(true, Ordering::AcqRel) {
+        panic!();
+    }
+    static mut YS: [u64; 100] = [1; 100];
+    unsafe { &YS }
+}
+
+fn iai_assign() {
+    let xs = get_xs();
+    let ys = get_ys();
+    store_load(black_box(xs), black_box(ys));
+}
+
+fn iai_store_load() {
+    let xs = get_xs();
+    let ys = get_ys();
+    assign(black_box(xs), black_box(ys));
+}
+
+//fn criterion_benchmark(c: &mut Criterion) {
+//    let mut xs: [u64; 10000] = [0; 10000];
+//    let ys: [u64; 10000] = [1; 10000];
+//
+//    c.bench_function("store and load", |b| {
+//        b.iter(|| store_load(black_box(&mut xs), black_box(&ys)))
+//    });
+//
+//    c.bench_function("assign sequential", |b| {
+//        b.iter(|| assign(black_box(&mut xs), black_box(&ys)))
+//    });
+//}
+
+//criterion_group!(benches, criterion_benchmark);
+//criterion_main!(benches);
+
+iai::main!(iai_assign, iai_store_load);

--- a/bin/snapshot
+++ b/bin/snapshot
@@ -1,0 +1,16 @@
+#!/bin/sh -eux
+
+ROOT=$(git rev-parse --show-toplevel)
+
+OLD_SNAPSHOT="$ROOT/snapshots/bench.snap"
+NEW_SNAPSHOT="$ROOT/snapshots/bench.snap.new"
+
+cargo criterion > "$NEW_SNAPSHOT"
+
+if [ -f "$OLD_SNAPSHOT" ]; then
+  diff "$NEW_SNAPSHOT" "$OLD_SNAPSHOT" || true
+fi
+
+mv "$NEW_SNAPSHOT" "$OLD_SNAPSHOT"
+
+[ -f "$NEW_SNAPSHOT" ] && rm "$NEW_SNAPSHOT" || true

--- a/snapshots/bench.snap
+++ b/snapshots/bench.snap
@@ -1,0 +1,19 @@
+iai_assign
+  Instructions:                 129 (No change)
+  L1 Accesses:                  163 (No change)
+  L2 Accesses:                    9 (No change)
+  RAM Accesses:                  28 (No change)
+  Estimated Cycles:            1188 (No change)
+
+iai_store_load
+  Instructions:                 130 (No change)
+  L1 Accesses:                  158 (No change)
+  L2 Accesses:                    6 (No change)
+  RAM Accesses:                  31 (No change)
+  Estimated Cycles:            1273 (No change)
+
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+


### PR DESCRIPTION
Oddly, cachegrind does not treat this as a deterministic test. The first
test now has a snapshot test as it is deterministic, but the first mover
pattern variant cannot be snapshotted as the numbers aren't stable.